### PR TITLE
Add yageo-th-resistors to the index

### DIFF
--- a/pools/yageo-th-resistors.yaml
+++ b/pools/yageo-th-resistors.yaml
@@ -1,0 +1,5 @@
+level: community
+source:
+        type: github
+        user: atoav
+        repo: horizon-pool-th-resistors


### PR DESCRIPTION
This adds the [yageo-th-resistors pool](https://github.com/atoav/horizon-pool-yageo-th-resistors) to the index.

This Repo has:
- packages for 6.3mm axial resistor (both horizontal and vertical)
- all metal film resistors from the Yageo MFR-25 series (scraped a while ago)